### PR TITLE
Introduce optional parameter parameter 'if_num' for command find_local_sta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Object files
+*.o
+
+# Libraries
+*.lib
+*.a
+
+# Shared objects
+*.so
+*.so.*
+
+# Sources
+*.tar.*
+
+# IDE/Editor noise
+*~
+.project
+.cproject
+.settings
+*.patch
+*.diff

--- a/hpav_test/README
+++ b/hpav_test/README
@@ -56,11 +56,11 @@ Usage
         If only the if_num is give then a help message listing the
         mandatory parameters is give for the MME.
 
-  Opreating Configuration file
+  Operating Configuration file
 
     hpav_test conf_file read|write|parse|modify if_num [parameters]
 
-  Opreating nvram
+  Operating nvram
 
     hpav_test nvram read|write|parse|modify  if_num [parameters]
 
@@ -71,10 +71,10 @@ Usage
   Upgrading firmware
 
     hpav_test fw_upgrade if_num mac bootloader firmware
-  
-  Finding station(s) by scaning each network interface
-    
-	hpav_test find_local_sta
+
+  Finding station(s) by scaning each network interface or a specific one
+
+    hpav_test find_local_sta [if_num]
 
   Security Tests
 
@@ -158,7 +158,7 @@ Supported MMEs
     tmi : tonemap index of wanted tonemap
     int_id : current tonemap interval list identifier
     direction : 0 -> TX, 1 -> RX
-	carrier_group : 0/1: carrier group, 255:enable RLE
+    carrier_group : 0/1: carrier group, 255:enable RLE
 
   mtk_vs_get_snr_req if_num sta_mac_address remote_sta_mac_address int_index carrier_group
     sta_mac_address : MAC address of the destination STA
@@ -215,10 +215,10 @@ Supported MMEs
 
   mtk_vs_pwm_generation_req if_num sta_mac_address PWM_mode frequency duty_cycle
     sta_mac_address : MAC address of the destination STA
-	PWM_mode: 0 (Disable), 1 (Enable)
-	frequency: (Hz)
-	duty_cycle: (%)
-  Ex: 00:11:22:33:44:55 1 10 50
+    PWM_mode: 0 (Disable), 1 (Enable)
+    frequency: (Hz)
+    duty_cycle: (%)
+    Ex: 00:11:22:33:44:55 1 10 50
 
   mtk_vs_spi_stats_req if_num sta_mac_address command
     sta_mac_address : MAC address of the destination STA

--- a/hpav_test/hpav_test/.gitignore
+++ b/hpav_test/hpav_test/.gitignore
@@ -1,0 +1,2 @@
+# binaries
+hpav_test

--- a/hpav_test/hpav_test/main.c
+++ b/hpav_test/hpav_test/main.c
@@ -394,13 +394,6 @@ int test_find_local_sta(int argc, char *argv[]) {
             // Sending MME on the channel
             printf("Interface successfully opened\n");
             printf("Sending Mstar VS_GET_NW_INFO.REQ on the channel\n");
-            if (argc > 0) {
-                if (!hpav_stomac(argv[0], dest_mac)) {
-                    printf("An error occured. Input mac value is in valid format...\n");
-                    return -1;
-                }
-            }
-
             memset(&mme_sent, 0x0,
                    sizeof(struct hpav_mtk_vs_get_nw_info_req));
             result = hpav_mtk_vs_get_nw_info_sndrcv(current_chan, dest_mac,


### PR DESCRIPTION
This PR adds support for the interface number parameter as supported already by other functions.

This is handy if you already know on which interface you expect a station and want to limit the search to this interface.
