### PR TITLE
hpav_test/libhpav: use strncpy instead of strcpy when dealing with in…

### DIFF
--- a/hpav_test/libhpav/hpav_if.c
+++ b/hpav_test/libhpav/hpav_if.c
@@ -120,7 +120,7 @@ int hpav_populate_mac_addr(hpav_if_t **interfaces_list) {
         // Reset params
         memset(&ioctl_params, 0, sizeof(struct ifreq));
         // Use interface name
-        strcpy(ioctl_params.ifr_name, first_if->name);
+        strncpy(ioctl_params.ifr_name, first_if->name, sizeof(ioctl_params.ifr_name) - 1);
         // Get MAC address
         ioctl(temp_socket, SIOCGIFHWADDR, &ioctl_params);
 


### PR DESCRIPTION
…terface name

libpcap enumerates also interfaces with names longer than IFNAMSIZ, e.g. "bluetooth-monitor". Without length checking, this results in a buffer overflow and compiling with -D_FORTIFY_SOURCE=2 (as used in newer Yocto distributions) results in an abort of the program.

Length checking here or the fact, that libpcap enumerates longer devices names, does not hurt here, since the used ioctls just will fail due to no matching interface, and thus the MAC address field stays zero-filled and the interface is in turn removed from the enumeration list.