### PR TITLE
Big refactoring: factor out common code and tidy up

### DIFF
--- a/hpav_test/hpav_test/conf_file.h
+++ b/hpav_test/hpav_test/conf_file.h
@@ -21,7 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-int conf_file_read(int argc, char *argv[]);
-int conf_file_write(int argc, char *argv[]);
+#include "hpav_api.h"
+
+int conf_file_read(hpav_chan_t *channel, int argc, char *argv[]);
+int conf_file_write(hpav_chan_t *channel, int argc, char *argv[]);
 int conf_file_parse(int argc, char *argv[]);
 int conf_file_modify(int argc, char *argv[]);

--- a/hpav_test/hpav_test/test_hpav.h
+++ b/hpav_test/hpav_test/test_hpav.h
@@ -21,5 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-int test_mme_cm_set_key_req(int interface_num_to_open, int argc, char *argv[]);
-int test_mme_cm_amp_map_req(int interface_num_to_open, int argc, char *argv[]);
+#include "hpav_api.h"
+
+int test_mme_cm_set_key_req(hpav_chan_t *channel, int argc, char *argv[]);
+int test_mme_cm_amp_map_req(hpav_chan_t *channel, int argc, char *argv[]);

--- a/hpav_test/hpav_test/test_mtk.h
+++ b/hpav_test/hpav_test/test_mtk.h
@@ -21,66 +21,68 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#include "hpav_api.h"
+
 // Declaration for Intellon test functions
 typedef unsigned int u_int32_t;
 void test_mme_mtk_printf_silence(void);
-int test_mme_mtk_vs_get_version_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_get_version_req(hpav_chan_t *channel, int argc,
                                     char *argv[]);
-int test_mme_mtk_vs_reset_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_reset_req(hpav_chan_t *channel, int argc,
                               char *argv[]);
-int test_mme_mtk_vs_reset_ind(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_reset_ind(hpav_chan_t *channel, int argc,
                               char *argv[]);
-int test_mme_mtk_vs_get_tonemask_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_get_tonemask_req(hpav_chan_t *channel, int argc,
                                      char *argv[]);
-int test_mme_mtk_vs_get_eth_phy_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_get_eth_phy_req(hpav_chan_t *channel, int argc,
                                     char *argv[]);
-int test_mme_mtk_vs_eth_stats_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_eth_stats_req(hpav_chan_t *channel, int argc,
                                   char *argv[]);
-int test_mme_mtk_vs_get_status_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_get_status_req(hpav_chan_t *channel, int argc,
                                    char *argv[]);
-int test_mme_mtk_vs_get_tonemap_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_get_tonemap_req(hpav_chan_t *channel, int argc,
                                     char *argv[]);
-int test_mme_mtk_vs_set_capture_state_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_set_capture_state_req(hpav_chan_t *channel, int argc,
                                           char *argv[]);
-int test_mme_mtk_vs_get_snr_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_get_snr_req(hpav_chan_t *channel, int argc,
                                 char *argv[]);
-int test_mme_mtk_vs_spi_stats_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_spi_stats_req(hpav_chan_t *channel, int argc,
                                   char *argv[]);
-int test_mme_mtk_vs_get_link_stats_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_get_link_stats_req(hpav_chan_t *channel, int argc,
                                        char *argv[]);
-int test_mme_mtk_vs_get_nw_info_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_get_nw_info_req(hpav_chan_t *channel, int argc,
                                     char *argv[]);
-int test_mme_mtk_vs_set_nvram_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_set_nvram_req(hpav_chan_t *channel, int argc,
                                   char *argv[]);
-int test_mme_mtk_vs_get_nvram_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_get_nvram_req(hpav_chan_t *channel, int argc,
                                   char *argv[]);
-int test_mme_mtk_vs_pwm_generation_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_pwm_generation_req(hpav_chan_t *channel, int argc,
                                        char *argv[]);
-int test_mme_mtk_vs_file_access_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_file_access_req(hpav_chan_t *channel, int argc,
                                     char *argv[]);
 #define MTK_VS_FILE_ACCESS_REQ_PARAMETER_FAIL -1
 #define MTK_VS_FILE_ACCESS_REQ_FAIL -2
-int test_mme_mtk_vs_get_pwm_stats_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_get_pwm_stats_req(hpav_chan_t *channel, int argc,
                                       char *argv[]);
 #define MTK_VS_GET_PWM_STATS_REQ_PARAMETER_FAIL -1
 #define MTK_VS_GET_PWM_STATS_REQ_FAIL -2
-int test_mme_mtk_vs_get_pwm_conf_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_get_pwm_conf_req(hpav_chan_t *channel, int argc,
                                      char *argv[]);
 #define MTK_VS_GET_PWM_CONF_REQ_PARAMETER_FAIL -1
 #define MTK_VS_GET_PWM_CONF_REQ_FAIL -2
-int test_mme_mtk_vs_set_pwm_conf_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_set_pwm_conf_req(hpav_chan_t *channel, int argc,
                                      char *argv[]);
 #define MTK_VS_SET_PWM_CONF_REQ_PARAMETER_FAIL -1
 #define MTK_VS_SET_PWM_CONF_REQ_FAIL -2
-int test_mme_mtk_vs_set_tx_cali_req(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_set_tx_cali_req(hpav_chan_t *channel, int argc,
                                     char *argv[]);
-int test_mme_mtk_vs_set_tx_cali_ind(int interface_num_to_open, int argc,
+int test_mme_mtk_vs_set_tx_cali_ind(hpav_chan_t *channel, int argc,
                                     char *argv[]);
-int test_mme_vc_vs_set_sniffer_conf_req(int interface_num_to_open, int argc,
+int test_mme_vc_vs_set_sniffer_conf_req(hpav_chan_t *channel, int argc,
                                     char* argv[]);
-int test_mme_vc_vs_set_remote_access_req(int interface_num_to_open, int argc,
+int test_mme_vc_vs_set_remote_access_req(hpav_chan_t *channel, int argc,
                                     char* argv[]);
-int test_mme_vc_vs_get_remote_access_req(int interface_num_to_open, int argc,
+int test_mme_vc_vs_get_remote_access_req(hpav_chan_t *channel, int argc,
                                     char* argv[]);
 #if !defined(_WIN32)
 #include <sys/types.h>

--- a/hpav_test/hpav_test/test_nvram.h
+++ b/hpav_test/hpav_test/test_nvram.h
@@ -21,6 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#include "hpav_api.h"
+
 #if defined(_MSC_VER)
 #define __packed
 #define __packed_end
@@ -30,8 +32,8 @@
 #define __packed_end __attribute__((packed))
 #endif
 
-int test_nvram_read(int argc, char *argv[]);
-int test_nvram_write(int argc, char *argv[]);
+int test_nvram_read(hpav_chan_t *channel, int argc, char *argv[]);
+int test_nvram_write(hpav_chan_t *channel, int argc, char *argv[]);
 int test_nvram_parse(int argc, char *argv[]);
 int test_nvram_modify(int argc, char *argv[]);
 

--- a/hpav_test/libhpav/hpav_api.h
+++ b/hpav_test/libhpav/hpav_api.h
@@ -25,6 +25,8 @@
 #ifndef HPAV_API_H
 #define HPAV_API_H
 
+#include <stdbool.h>
+
 #ifndef _WIN32
 #include <stdlib.h>
 #include <string.h>
@@ -141,6 +143,13 @@ int hpav_get_interfaces(struct hpav_if **interface_list,
 // Manage interfaces
 struct hpav_if *hpav_get_interface_by_index(struct hpav_if *interfaces,
                                             unsigned int if_num);
+struct hpav_if *hpav_get_interface_by_name(struct hpav_if *interfaces,
+                                           char *if_name,
+                                           unsigned int *if_num);
+struct hpav_if *hpav_get_interface_by_index_or_name(struct hpav_if *interfaces,
+                                                    char *arg,
+                                                    bool *was_index,
+                                                    unsigned int *if_num) ;
 unsigned int hpav_get_number_of_interfaces(struct hpav_if *interfaces);
 
 // Free a list of interfaces returned by hpav_get_interfaces


### PR DESCRIPTION
Many functions use the very same code which makes it difficult to maintain and extend the tool.
This change introduces new functions which are then integrated into existing functionality.

The original idea was to replace the interface number handling with code that allows to use existing interface _names_ (at least
on Linux). Reason is that using interface _numbers_ requires two steps in shell scripts: with the first step, you have to determine
the interface number and in the second step, you can pass it to the actual hpav_test command you want to execute. However, this
is racy, especially during the boot phase of a Linux system, when interfaces appear and the interface numbering may change.
This could result in sending/expecting the chip on the wrong interface.

So the initial idea was to extend the tool that both, a number or a name, can be passed as argument.
While implementing, it then turned out, that it makes sense to tune the whole code base a little bit.

This work is based on my previous pull request. Since there is no feedback yet, and since this is a really big chance, I mark this as draft PR for the moment.
Please share your comments whether you're fine with my approach and/or want I should do better.

Note: I've done basic regression testing for some commands, but not a full test cycle for every single possible use-case. While all functionality should also work on Windows systems, I do not have a compile environment for Windows nor any experience on this platform.
